### PR TITLE
Fix gen-version.mk to correctly call gen-version.sh when . is not in your PATH

### DIFF
--- a/gen-version.mk
+++ b/gen-version.mk
@@ -15,8 +15,8 @@ endif
 -include $(PROJECT_RELEASE_FILE)
 ifeq ($(strip $($(PROJECT_VERSION_VAR))),)
 $(PROJECT_VERSION_VAR)_DEP=$(PROJECT_VERSION_VAR)
-$(PROJECT_VERSION_VAR): gen-version.sh .git/$(shell $(GIT) symbolic-ref HEAD)
-	@gen-version.sh $(PROJECT) $(PROJECT_VERSION_VAR) $(PROJECT_VERSION_VAR)
+$(PROJECT_VERSION_VAR): ./gen-version.sh .git/$(shell $(GIT) symbolic-ref HEAD)
+	@./gen-version.sh $(PROJECT) $(PROJECT_VERSION_VAR) $(PROJECT_VERSION_VAR)
 -include $(PROJECT_VERSION_VAR)
 else
 $(PROJECT_VERSION_VAR)_DEP=
@@ -24,4 +24,3 @@ endif
 clean-version:
 	$(RM) $(PROJECT_VERSION_VAR)
 clean: clean-version
-


### PR DESCRIPTION
When . is not in your PATH, make is unable to execute gen-version.sh (tested on ubuntu 11.04.)

Calling it with ./gen-version.sh instead fixes this.
