### PR TITLE
Fix a typo in the 'codec' variable name

### DIFF
--- a/simplemkv/tomp4.py
+++ b/simplemkv/tomp4.py
@@ -194,7 +194,7 @@ def mp4_add_video_cmd(mp4file, video, fps, **opts):
 def ffmpeg_convert_audio_cmd(old, new, **opts):
     bitrate = opts.get('bitrate', '128')
     channels = opts.get('channels', '2')
-    codec = opts.get('codec', 'libfaac')
+    codec = opts.get('a_codec', 'libfaac')
     verbosity = opts.get('verbosity', 0)
     if str(channels) == '5.1':
         channels = '6'


### PR DESCRIPTION
It was otherwise not possible to override the codec on the command line using the `--audio-codec` option.
